### PR TITLE
Fix typings with ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "./dist/index.js",
   "exports": {
     "require": "./dist/index.js",
-    "default": "./dist/index-esm.mjs"
+    "default": "./dist/index-esm.mjs",
+    "types": "./dist/index.d.ts"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Without this change, I get this error:

```
serial.ts:1:49 - error TS7016: Could not find a declaration file for module '@serialport/bindings-interface'. '.../node_modules/@serialport/bindings-interface/dist/index-esm.mjs' implicitly has an 'any' type.
```

Once this change is made, everything typechecks correctly.