### PR TITLE
Add friendlyName to PortInfo interface <superseeded - will delete upon confirmation of alternative fix>

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -11,6 +11,7 @@ export interface PortInfo {
   locationId: string | undefined
   productId: string | undefined
   vendorId: string | undefined
+  friendlyName?: string | undefined
 }
 
 export interface OpenOptions {


### PR DESCRIPTION
Fix for https://github.com/serialport/node-serialport/issues/2600

Adds `friendlyName` (Windows specific property) to Port definition