### PR TITLE
Add friendlyName and lowLatency to interfaces

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -11,6 +11,7 @@ export interface PortInfo {
   locationId: string | undefined
   productId: string | undefined
   vendorId: string | undefined
+  friendlyName: string | undefined
 }
 
 export interface OpenOptions {
@@ -56,6 +57,7 @@ export interface PortStatus {
   cts: boolean
   dsr: boolean
   dcd: boolean
+  lowLatency: boolean
 }
 
 /**


### PR DESCRIPTION
Alternative fix for https://github.com/serialport/node-serialport/issues/2600

Add `friendlyName `to `PortInfo`, and `LowLatency` to `PortStatus`