### PR TITLE
Add product property to PortInfo

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -6,6 +6,7 @@
 export interface PortInfo {
   path: string
   manufacturer: string | undefined
+  product?: string | undefined
   serialNumber: string | undefined
   pnpId: string | undefined
   locationId: string | undefined

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint": "tsc && eslint lib/**/*.ts",
     "format": "eslint lib/**/*.ts --fix",
     "clean": "rm -rf dist-ts dist",
-    "build": "npm run clean && tsc -p tsconfig-build.json && rollup -c && node -r esbuild-register bundle-types",
+    "build": "npm run clean && tsc -p tsconfig-build.json && rollup -c --bundleConfigAsCjs && node -r esbuild-register bundle-types",
     "prepublishOnly": "npm run build",
     "semantic-release": "semantic-release"
   },


### PR DESCRIPTION
I would like to add a product property to PortInfo to provide the USB device's product/model string separately.

Implementation for Mac/Linux in  https://github.com/serialport/bindings-cpp/pull/138