### PR TITLE
fix: resolution of types from ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,6 @@
   "description": "SerialPort Bindings Typescript Types",
   "types": "dist/index.d.ts",
   "main": "./dist/index.js",
-  "exports": {
-    "require": "./dist/index.js",
-    "default": "./dist/index-esm.mjs"
-  },
   "publishConfig": {
     "access": "public"
   },

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -6,7 +6,6 @@ export default {
     resolve({}),
   ],
   output: [
-    { format: 'esm', file: './dist/index-esm.mjs' },
     { format: 'cjs', file: './dist/index.js' },
   ],
   external: [],


### PR DESCRIPTION
While migrating a project that depends on this package to ESM, I noticed that the type definitions are wrong. They try to make the package look like it contains ESM definitions, but this doesn't actually work, as can be tested with https://arethetypeswrong.github.io/

Removing the incorrect definitions lets TypeScript detect what this package really is: CommonJS and nothing more.

**Output of arethetypeswrong before this change:**
```
@serialport/bindings-interface v1.2.2

Build tools:
- typescript@4.5.5
- rollup@2.67.0
- esbuild@0.14.18
- @microsoft/api-extractor@7.19.4

❌ Import resolved to JavaScript files, but no type declarations were found. https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/UntypedResolution.md


┌───────────────────┬──────────────────────────────────┐
│                   │ "@serialport/bindings-interface" │
├───────────────────┼──────────────────────────────────┤
│ node10            │ 🟢                               │
├───────────────────┼──────────────────────────────────┤
│ node16 (from CJS) │ 🟢 (CJS)                         │
├───────────────────┼──────────────────────────────────┤
│ node16 (from ESM) │ ❌ No types                      │
├───────────────────┼──────────────────────────────────┤
│ bundler           │ ❌ No types                      │
└───────────────────┴──────────────────────────────────┘
```

**Output of arethetypeswrong after this change:**
```
@serialport/bindings-interface v0.0.0-development

Build tools:
- typescript@5.1.6
- rollup@3.28.1
- esbuild@0.24.0
- @microsoft/api-extractor@7.36.4

 No problems found 🌟


┌───────────────────┬──────────────────────────────────┐
│                   │ "@serialport/bindings-interface" │
├───────────────────┼──────────────────────────────────┤
│ node10            │ 🟢                               │
├───────────────────┼──────────────────────────────────┤
│ node16 (from CJS) │ 🟢 (CJS)                         │
├───────────────────┼──────────────────────────────────┤
│ node16 (from ESM) │ 🟢 (CJS)                         │
├───────────────────┼──────────────────────────────────┤
│ bundler           │ 🟢                               │
└───────────────────┴──────────────────────────────────┘
```