### PR TITLE
Add friendlyName to PortInfo

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -11,6 +11,7 @@ export interface PortInfo {
   locationId: string | undefined
   productId: string | undefined
   vendorId: string | undefined
+  friendlyName: string | undefined
 }
 
 export interface OpenOptions {


### PR DESCRIPTION
This is needed in combination with https://github.com/serialport/bindings-cpp/pull/219 to implement friendly name support on all platforms.